### PR TITLE
Disable archive downloads (Microsoft is abusing them)

### DIFF
--- a/PulumiWebServer/Nix/gitea/gitea-config.nix
+++ b/PulumiWebServer/Nix/gitea/gitea-config.nix
@@ -64,6 +64,9 @@
           RENDER_COMMAND = ''${docutils}/bin/rst2html.py'';
           IS_INPUT_FILE = false;
         };
+        repository = {
+          DISABLE_DOWNLOAD_SOURCE_ARCHIVES = true;
+        };
       };
     };
 


### PR DESCRIPTION
I have had a Microsoft crawler, most recently 20.171.207.202/24 , spinning for weeks repeatedly downloading the source archives for what seems to be every commit in most of my repos. Fuck them.