### PR TITLE
Delete spare service dep

### DIFF
--- a/PulumiWebServer/Nix/radicale/radicale-container.nix
+++ b/PulumiWebServer/Nix/radicale/radicale-container.nix
@@ -140,12 +140,6 @@ in {
       };
     };
 
-    # The container service should wait for secrets to be available
-    systemd.services."container@radicale" = {
-      after = ["sops-nix.service"];
-      requires = ["sops-nix.service"];
-    };
-
     # nginx on the host proxies to the container
     services.nginx.virtualHosts."${cfg.subdomain}.${cfg.domain}" = {
       forceSSL = true;


### PR DESCRIPTION
We use the fallback script method of sops-nix which doesn't result in a running systemd service.